### PR TITLE
Fix race condition by copying chunk data in Subscriber's read method

### DIFF
--- a/pkg/io/subscriber.go
+++ b/pkg/io/subscriber.go
@@ -208,6 +208,12 @@ func (s *Subscriber) read(reader *bufio.Reader) chan []byte {
 			} else {
 				chunk, err = reader.ReadSlice(s.config.MessageDelimiter)
 				bytesRead = len(chunk)
+				// copy the data for a race condition
+				if err == nil && bytesRead > 0 {
+					chunkCopy := make([]byte, bytesRead)
+					copy(chunkCopy, chunk)
+					chunk = chunkCopy
+				}
 			}
 
 			if err != nil && errors.Cause(err) != io.EOF {


### PR DESCRIPTION

### Motivation / Background

This PR addresses a concurrency-related bug in `Subscriber.read()` where slices returned by `bufio.Reader.ReadSlice` were shared between iterations, leading to race conditions when the consumer of the channel retained or mutated the chunk after it was reused by the reader.

This issue has been documented in [#581](https://github.com/ThreeDotsLabs/watermill/issues/581#issue-3195250754). The race occurs because `ReadSlice` reuses an internal buffer, so passing the slice directly through the channel can lead to unsafe access if it is used concurrently elsewhere.

Fixes #581

### Details

To resolve the race condition, the read loop now **copies the chunk into a new slice** before sending it over the channel. This ensures that each message chunk sent to downstream consumers is a safe, isolated copy that won't be invalidated by future reads.

Benchmarking showed a negligible decrease in throughput in exchange for guaranteed safety in concurrent environments.

### Alternative approaches considered



### Checklist

- [ ] I wrote tests for the changes.
- [ ] All tests are passing.
  - If you are testing a Pub/Sub, you can start Docker with `make up`.
  - You can start with `make test_short` for a quick check.
  - If you want to run all tests, use `make test`.
- [x] Code has no breaking changes.
- [ ] _(If applicable)_ documentation on [watermill.io](https://watermill.io/) is updated.
